### PR TITLE
Fix bullets in CoreModelObject Javadoc

### DIFF
--- a/src/main/java/org/spdx/core/CoreModelObject.java
+++ b/src/main/java/org/spdx/core/CoreModelObject.java
@@ -52,20 +52,24 @@ import org.spdx.storage.IModelStore.ModelUpdate;
  * is passed as a parameter.
  * <p>
  * There are 2 methods of setting values:
- *   - call the setPropertyValue, clearValueCollection or addValueToCollection methods - this will call the modelStore and store the
- *     value immediately
- *   - Gather a list of updates by calling the updatePropertyValue, updateClearValueList, or updateAddPropertyValue
+ * <ul>
+ *   <li>Call the setPropertyValue, clearValueCollection or addValueToCollection methods.
+ *     This will call the modelStore and store the value immediately.</li>
+ *   <li>Gather a list of updates by calling the updatePropertyValue, updateClearValueList, or updateAddPropertyValue
  *     methods.  These methods return a ModelUpdate which can be applied later by calling the <code>apply()</code> method.
  *     A convenience method <code>Write.applyUpdatesInOneTransaction</code> will perform all updates within
  *     a single transaction. This method may result in higher performance updates for some Model Store implementations.
  *     Note that none of the updates will be applied until the storage manager update method is invoked.
+ *   </li>
+ * </ul>
  * <p>
  * Property values are restricted to the following types:
- *   - String - Java Strings
- *   - Boolean - Java Boolean or primitive boolean types
- *   - CoreModelObject - A concrete subclass of this type
- *   - {@literal Collection<T>} - A Collection of type T where T is one of the supported non-collection types
- * <p>
+ * <ul>
+ *   <li>String - Java Strings</li>
+ *   <li>Boolean - Java Boolean or primitive boolean types</li>
+ *   <li>CoreModelObject - A concrete subclass of this type</li>
+ *   <li>{@literal Collection<T>} - A Collection of type T where T is one of the supported non-collection types</li>
+ * </ul>
  * This class also handles the conversion of a CoreModelObject to and from a TypeValue for storage in the ModelStore.
  *
  * @author Gary O'Neall
@@ -107,7 +111,7 @@ public abstract class CoreModelObject {
 	/**
 	 * Open or create a model object with the default store
 	 * @param objectUri Anonymous ID or URI for the model object
-	 * @param specVersion - version of the SPDX spec the object complies with
+	 * @param specVersion Version of the SPDX spec the object complies with
 	 * @throws InvalidSPDXAnalysisException on any SPDX related exception
 	 */
 	protected CoreModelObject(String objectUri, String specVersion) throws InvalidSPDXAnalysisException {

--- a/src/main/java/org/spdx/core/NotEquivalentReason.java
+++ b/src/main/java/org/spdx/core/NotEquivalentReason.java
@@ -28,24 +28,57 @@ import org.spdx.storage.PropertyDescriptor;
  * @author Gary O'Neall
  */
 public class NotEquivalentReason {
-	
+
+	/**
+	 * Enum representing the reasons why two model objects are not equivalent.
+	 */
 	public enum NotEquivalent {
-		DIFFERENT_CLASS, MISSING_PROPERTY, PROPERTY_NOT_EQUIVALENT, COMPARE_PROPERTY_MISSING}
-		
+		/**
+		 * Indicates that the objects are of different classes.
+		 */
+		DIFFERENT_CLASS,
+
+		/**
+		 * Indicates that a property is missing in one of the objects.
+		 */
+		MISSING_PROPERTY,
+
+		/**
+		 * Indicates that a property value is not equivalent between the objects.
+		 */
+		PROPERTY_NOT_EQUIVALENT,
+
+		/**
+		 * Indicates that a property to compare is missing.
+		 */
+		COMPARE_PROPERTY_MISSING
+	}
+
 		NotEquivalent reason;
 		PropertyDescriptor property = null;
-		
+
+		/**
+		 * Constructs a NotEquivalentReason with the specified reason.
+		 * 
+		 * @param reason the reason why the objects are not equivalent
+		 */
 		public NotEquivalentReason(NotEquivalent reason) {
 			this.reason = reason;
 		}
-		
+
+		/**
+		 * Constructs a NotEquivalentReason with the specified reason and property.
+		 * 
+		 * @param reason the reason why the objects are not equivalent
+		 * @param property the property descriptor associated with the reason
+		 */
 		public NotEquivalentReason(NotEquivalent reason, PropertyDescriptor property) {
 			this(reason);
 			this.property = property;
 		}
 
 		/**
-		 * @return the reason
+		 * @return the reason why the objects are not equivalent
 		 */
 		public NotEquivalent getReason() {
 			return reason;

--- a/src/main/java/org/spdx/licenseTemplate/LicenseTemplateRule.java
+++ b/src/main/java/org/spdx/licenseTemplate/LicenseTemplateRule.java
@@ -48,9 +48,9 @@ public class LicenseTemplateRule {
 	/**
 	 * Create a new LicenseTemplateRule
 	 * @param name Name of the rule - must not be null
-	 * @param type - type of rule
-	 * @param original - Original text - must not be null
-	 * @param example - Example text - may be null
+	 * @param type Type of rule
+	 * @param original Original text - must not be null
+	 * @param example Example text - may be null
 	 * @throws LicenseTemplateRuleException if the license template could not be parsed
 	 */
 	public LicenseTemplateRule(String name, RuleType type, String original, String match, String example) throws LicenseTemplateRuleException {


### PR DESCRIPTION
Add `<ul>` `<li>` HTML markups to CoreModelObject so the bullet lists display properly in the API doc

Also add description to NotEquivalent Enums